### PR TITLE
Correction des freezes et crashs et amélioration de l'UI 

### DIFF
--- a/sources/Item.py
+++ b/sources/Item.py
@@ -125,7 +125,7 @@ class Item:
         )
         rect_nom    : Rect = Rect(
             (abscisses, rect_sprite.bottom),
-           nom.size,
+           nom.get_rect().size,
         )
         pos_prix   : Pos = Pos(
             abscisses + rect_sprite.width // 2 + Jeu.pourcentage_largeur(1),

--- a/sources/fonctions_etats.py
+++ b/sources/fonctions_etats.py
@@ -204,7 +204,7 @@ def credits(duree : Duree = Duree(s=5)) -> None:
     
     deplacement : Deplacement = Deplacement(
         Pos(Jeu.pourcentage_largeur(50), Jeu.hauteur),
-        Pos(Jeu.pourcentage_largeur(50), - texte_credits2.height - 20),  # pour laisser le "et Nils" aller hors écran
+        Pos(Jeu.pourcentage_largeur(50), - texte_credits2.get_height() - 20),  # pour laisser le "et Nils" aller hors écran
     )
     
     debut : Duree = copy(Jeu.duree_execution)
@@ -215,7 +215,7 @@ def credits(duree : Duree = Duree(s=5)) -> None:
         
         Jeu.fenetre.fill(NOIR)
         blit_centre(Jeu.fenetre, texte_credits , pos.tuple)
-        blit_centre(Jeu.fenetre, texte_credits2, (pos + Vecteur(0, texte_credits2.height + 10)).tuple)
+        blit_centre(Jeu.fenetre, texte_credits2, (pos + Vecteur(0, texte_credits2.get_height() + 10)).tuple)
         
         Jeu.display_flip()
     Jeu.changer_etat(Jeu.precedent_etat)


### PR DESCRIPTION
1. Fix du freeze quand on clique vite sur une autre carte en pleine animation :
   - `sources/Carte.py` : la fin d’animation ne force plus `IDLE` si un nouvel état a été demandé.

2. Affichage du tour adverse :
   - `sources/UI.py` : quand `Jeu.attaques_restantes_joueur <= 0`, le texte devient “Tour de l’adversaire” au lieu d'un nombre négatif de main restantes.

3. Survol cartes :
   - `sources/UI.py` et `sources/Carte.py` : la carte survolée est dessinée en dernier, donc au‑dessus des autres + surélevée et avec un léger zoom.

4. Crash shop (`Surface.size`) et crédits (`Surface.height`):
   - `sources/Item.py` : `nom.size` → `nom.get_rect().size`.
   - `sources/fonctions_etats.py` : `texte_credits2.height` → `texte_credits2.get_height()`.